### PR TITLE
Re-enable php syntax highlight at docs

### DIFF
--- a/docs/module.md
+++ b/docs/module.md
@@ -12,7 +12,7 @@ Module configure
 
 ### Example
 Add to config file:
-```
+```php
 	'modules' => [
 		'roxymce' => [
 			'class' => 'navatech\roxymce\Module',

--- a/docs/widget.md
+++ b/docs/widget.md
@@ -13,17 +13,15 @@ Widget Usage
 ### Example
 In your view file, call roxymce widget
 #### Include ActiveRecord Model
-~~~
-[php]
+```php
 echo \navatech\roxymce\widgets\RoxyMceWidget::widget([
 	'model'     => app\models\Post::findOne(1),
 	'attribute' => 'content',
 ]);
-~~~
+```
 #### Sample HTML without ActiveRecord Model
-~~~
-[php]
+```php
 echo \navatech\roxymce\widgets\RoxyMceWidget::widget([
 	'name' => 'Post[content]'
 ]);
-~~~
+```

--- a/docs/without.md
+++ b/docs/without.md
@@ -13,8 +13,7 @@ In this case, you can use roxymce without TinyMCE intergrated. Just use with fan
 ### Example
 
 #### With Fancybox
-~~~
-[php]
+```php
 <?php
 use navatech\roxymce\assets\BootstrapTreeviewAsset;
 use navatech\roxymce\assets\FancyBoxAsset;
@@ -37,11 +36,10 @@ BootstrapTreeviewAsset::register($this);
 <script>
 	$('.fancybox').fancybox();
 </script>
-~~~
+```
 
 #### With Bootstrap modal
-~~~
-[php]
+```php
 <?php
 use navatech\roxymce\assets\BootstrapTreeviewAsset;
 use navatech\roxymce\assets\FancyBoxAsset;
@@ -74,4 +72,4 @@ BootstrapTreeviewAsset::register($this);
 		</div><!-- /.modal-content -->
 	</div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
-~~~
+```


### PR DESCRIPTION
I think it's good to re-enable php syntax highlight at docs.